### PR TITLE
Feature/create company

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,81 @@
 
 # env
 /.env
+
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8 (preonboarding-wantedlab)" project-jdk-type="Python SDK" />
+  <component name="PythonCompatibilityInspectionAdvertiser">
+    <option name="version" value="3" />
+  </component>
 </project>

--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -7,7 +7,7 @@
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
       <option name="fileExtension" value="py" />
-      <option name="immediateSync" value="true" />
+      <option name="immediateSync" value="false" />
       <option name="name" value="black" />
       <option name="output" value="$FilePath$" />
       <option name="outputFilters">

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -11,6 +11,7 @@ migrate = Migrate()
 
 def create_app():
     app = Flask(__name__)
+    app.debug = True
     app.config.from_object(config)
 
     # ORM

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,7 @@
 from flask import Flask
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
+from flask_restx import Api
 
 import config
 
@@ -16,5 +17,12 @@ def create_app():
     db.init_app(app)
     migrate.init_app(app, db)
     from . import models
+
+    # flask_restx
+    api = Api(app)
+
+    from .companies import companies_controller as company
+
+    api.add_namespace(company.ns, "/companies")
 
     return app

--- a/app/companies/companies_controller.py
+++ b/app/companies/companies_controller.py
@@ -1,10 +1,16 @@
+from flask import jsonify, make_response, json
 from flask_restx import Namespace, Resource, reqparse
+from .companies_service import CompaniesService
 
 ns = Namespace("companies")
 
 
 @ns.route("")
 class CreateCompany(Resource):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.service = CompaniesService()
+
     def post(self):
         parser = reqparse.RequestParser()
         parser.add_argument(
@@ -17,8 +23,12 @@ class CreateCompany(Resource):
             type=list,
             required=True,
             location="json",
-            action="append",
         )
         parser.add_argument("x-wanted-language", type=str, location="headers")
         args = parser.parse_args()
-        return args
+
+        result = self.service.create_company(args)
+        if result["ok"]:
+            return result["data"]
+        else:
+            return make_response(result["error"], result["http_status"])

--- a/app/companies/companies_controller.py
+++ b/app/companies/companies_controller.py
@@ -1,0 +1,24 @@
+from flask_restx import Namespace, Resource, reqparse
+
+ns = Namespace("companies")
+
+
+@ns.route("")
+class CreateCompany(Resource):
+    def post(self):
+        parser = reqparse.RequestParser()
+        parser.add_argument(
+            "company_name",
+            type=dict,
+            required=True,
+        )
+        parser.add_argument(
+            "tags",
+            type=list,
+            required=True,
+            location="json",
+            action="append",
+        )
+        parser.add_argument("x-wanted-language", type=str, location="headers")
+        args = parser.parse_args()
+        return args

--- a/app/companies/companies_service.py
+++ b/app/companies/companies_service.py
@@ -1,0 +1,90 @@
+from __future__ import print_function
+from datetime import datetime
+from sqlalchemy import create_engine, orm
+
+from .. import db
+from ..models import Company, Language, CompanyName, CompanyTag
+import config
+
+# 트랜잭션을 하기 전에 미리 생성합니다.
+def create_company():
+    new_company = Company(created_at=datetime.now())
+    db.session.add(new_company)
+    db.session.commit()
+    return new_company
+
+
+# 트랜젝션을 실패할 경우 삭제합니다.
+def delete_company(company):
+    db.session.delete(company)
+    db.session.commit()
+    return
+
+
+def find_or_create_language(keyword, session):
+    exist_lang = Language.query.filter_by(lang_tag=keyword).first()
+    if exist_lang is None:
+        new_language = Language(lang_tag=keyword)
+        session.add(new_language)
+        return new_language
+    else:
+        return exist_lang
+
+
+def check_and_create_company_name(keyword, company_id, lang_id, session):
+    exist_name = CompanyName.query.filter_by(company_name=keyword).first()
+    if exist_name is None:
+        new_name = CompanyName(
+            company_id=company_id,
+            lang_id=lang_id,
+            company_name=keyword,
+        )
+        session.add(new_name)
+        return True
+    else:
+        return False
+
+
+class CompaniesService:
+    def create_company(self, args):
+        http_status = 200
+        error = ""
+        language_dict = dict()
+        name_dict = dict()
+        tags_dict = dict()
+
+        engine = create_engine(config.SQLALCHEMY_DATABASE_URI)
+        session = orm.Session(engine)
+
+        new_company = create_company()
+        try:
+            # 회사 이름 등록하기.
+            for key, val in args.company_name.items():
+                # 회사 이름: 이미 존재하는 회사 이름이면 에러를 리턴하고, 아니면 생성합니다.
+                # 언어: 등록하지 않은 언어일 경우 생성합니다.
+                language = find_or_create_language(key, session)
+                language_dict[key] = language
+                # 회사 이름: 동일한 이름의 회사가 존재하면 에러를, 아니면 이름을 데이터로 저장합니다.
+                exist_name = CompanyName.query.filter_by(company_name=val)
+                is_succeed_to_create_name = check_and_create_company_name(
+                    keyword=val,
+                    company_id=new_company.id,
+                    lang_id=language.id,
+                    session=session,
+                )
+                if is_succeed_to_create_name is False:
+                    http_status = 400
+                    error = "이미 존재하는 이름입니다."
+                    raise Exception()
+                name_dict[key] = val
+
+            # 4. 태그: 회사를 이용해서 태그를 등록합니다.
+            session.commit()
+            return {"ok": True, "http_status": 200, "data": "s"}
+        except Exception as err:
+            print("EXCEPTION", err)
+            session.rollback()
+            delete_company(new_company)
+            return {"ok": False, "http_status": http_status, "error": error}
+        finally:
+            session.close()


### PR DESCRIPTION
## 종류

- [ ] 버그 수정
- [x] 신규 기능 추가
- [ ] 리팩토링
- [ ] 테스트
- [ ] 기타

## 개요

- 회사를 등록하는 기능을 추가했습니다.

## 상세한 내용

- NestJS의 의존성 주입 패턴을 참고하여, 서비스 클래스를 컨트롤러 생성자에 불러와 활용하도록 작성했습니다.
- flask_restx 를 설치해 요청 값을 검증하고 URI 를 설정하는 등 REST API 를 제작하는데 활용했습니다.
- 회사를 생성하는 과정은 트랜잭션을 사용했으며, 수행 과정은 아래와 같습니다.
    - 새로운 company 를 생성해 company.id 를 받아옵니다.
    - 회사 이름 객체의 key 를 통해 language 를 데이터베이스에 등록합니다. 해당 데이터를 languages_cache 딕셔너리에 등록하여 향후 재사용합니다.
    - company.id 와 language.id 를 포함해  company_name 을 등록합니다. 만약 동일한 이름이 있을 경우 트랜잭션을 롤백하고 종료합니다.
    - company_tag 를 등록합니다. 회사 이름의 언어 설정과 태그의 언어 설정이 불일치하는 경우를 감안하여, 만약 languages_cache 에 없는 언어라면 language 를 새로 생성합니다. 생성한 태그의 이름을 tags_cache 리스트에 등록합니다.
    - 헤더의 x-wanted-language 에 맞게 응답으로 보낼 결과를 가공 후 컨트롤러로 보내 응답으로 전달합니다.

resolves: #3