### PR TITLE
Fix: 회사 조회 API 의 에러 처리를 수정

### DIFF
--- a/app/companies/companies_service.py
+++ b/app/companies/companies_service.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from datetime import datetime
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.orm import Session
@@ -117,11 +116,14 @@ class CompaniesService:
         try:
             keyword = args["keyword"]
             lang_tag = args["x-wanted-language"]
+            target_company = CompanyName.query.filter_by(company_name=keyword).first()
+
+            if target_company is None:
+                return {"ok": False, "http_status": 404, "error": "해당 회사가 존재하지 않습니다."}
+
+            target_company = convert_orm_to_dict(target_company)
             target_language = convert_orm_to_dict(
                 Language.query.filter_by(lang_tag=lang_tag).first()
-            )
-            target_company = convert_orm_to_dict(
-                CompanyName.query.filter_by(company_name=keyword).first()
             )
 
             company_detail = (
@@ -136,8 +138,6 @@ class CompaniesService:
                 .add_columns(CompanyName.company_name, CompanyTag.tag_name)
                 .all()
             )
-            if len(company_detail) == 0:
-                return {"ok": False, "http_status": 404, "error": "해당 회사가 존재하지 않습니다."}
 
             result = dict()
             result["company_name"] = company_detail[0][1]


### PR DESCRIPTION
## 종류

- [x] 버그 수정
- [ ] 신규 기능 추가
- [ ] 리팩토링
- [ ] 테스트
- [ ] 기타

## 개요

이름으로 회사를 조회할 때, 존재하지 않는 이름일 경우의 처리 과정을 수정했습니다.

## 상세한 내용

- 기존에는 join 으로 얻은 최종 결과를 기준으로 존재 유무를 확인했습니다. 
- 하지만 회사의 이름으로 아이디를 추출하는 것을 처음으로 수행함에 따라, 이 조건문을 처음 부분에 적용하는 것이 옳다는 것을 확인했습니다.
- 이제 URI 파라미터의 이름 키워드로 target_company 를 조회한 후, 그것에 대한 조건문을 달아 존재하지 않을 때의 처리를 수행합니다.

resolves: #5